### PR TITLE
Don't authorize requests with the existing token if there was an error when refreshing

### DIFF
--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -268,7 +268,7 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
     }
     authorizeRequestControlFlow: if isAuthorizableRequest,
        let accessToken = accessToken,
-       !accessToken.isEmpty {
+       !accessToken.isEmpty, args.error == nil {
       request.setValue(
         "Bearer \(accessToken)",
         forHTTPHeaderField: "Authorization"


### PR DESCRIPTION
Add error condition check in AuthSession.swift authorization logic, this ensure refresh errors are passed to clients instead of using stale tokens